### PR TITLE
6000.0/oculus app spacewarp

### DIFF
--- a/Packages/com.unity.render-pipelines.core/Runtime/XR/XRPass.cs
+++ b/Packages/com.unity.render-pipelines.core/Runtime/XR/XRPass.cs
@@ -355,6 +355,12 @@ namespace UnityEngine.Experimental.Rendering
             StopSinglePass(cmd.m_WrappedCommandBuffer);
         }
 
+        public bool IsXRTarget(RenderTargetIdentifier targetID)
+        {
+            return new RenderTargetIdentifier(renderTarget, 0) == new RenderTargetIdentifier(targetID, 0) ||
+                   new RenderTargetIdentifier(motionVectorRenderTarget, 0) == new RenderTargetIdentifier(targetID, 0);
+        }
+
         /// <summary>
         /// Returns true if the pass was setup with expected mesh and material.
         /// </summary>

--- a/Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/MotionVectorPass.hlsl
+++ b/Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/MotionVectorPass.hlsl
@@ -78,7 +78,9 @@ void vert(
     MotionVectorPassVaryings mvOutput = (MotionVectorPassVaryings)0;
     MotionVectorPassOutput currentFrameMvData = (MotionVectorPassOutput)0;
     output = BuildVaryings(input, currentFrameMvData);
+#if !defined(APPLICATION_SPACE_WARP_MOTION)
     ApplyMotionVectorZBias(output.positionCS);
+#endif
     packedOutput = PackVaryings(output);
 
 #if defined(HAVE_VFX_MODIFICATION) && !VFX_FEATURE_MOTION_VECTORS
@@ -176,6 +178,10 @@ float4 frag(
     LODFadeCrossFade(input.positionCS);
 #endif
 
+#if defined(APPLICATION_SPACE_WARP_MOTION)
+    return float4(CalcAswNdcMotionVectorFromCsPositions(mvInput.positionCSNoJitter, mvInput.previousPositionCSNoJitter), 1);
+#else
     return float4(CalcNdcMotionVectorFromCsPositions(mvInput.positionCSNoJitter, mvInput.previousPositionCSNoJitter), 0, 0);
+#endif
 }
 #endif

--- a/Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Targets/UniversalTarget.cs
+++ b/Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Targets/UniversalTarget.cs
@@ -1156,7 +1156,7 @@ namespace UnityEditor.Rendering.Universal.ShaderGraph
                 renderStates = CoreRenderStates.MotionVector(target),
                 pragmas = CorePragmas.MotionVectors,
                 defines = new DefineCollection(),
-                keywords = new KeywordCollection(),
+                keywords = new KeywordCollection() { CoreKeywordDescriptors.ApplicationSpaceWarpMotion },
                 includes = CoreIncludes.MotionVectors,
 
                 // Custom Interpolator Support
@@ -1229,7 +1229,7 @@ namespace UnityEditor.Rendering.Universal.ShaderGraph
 
                 // Port Mask
                 validVertexBlocks = CoreBlockMasks.Vertex,
-                // NB Color is not strickly needed for scene picking but adding it here so that there are nodes to be 
+                // NB Color is not strickly needed for scene picking but adding it here so that there are nodes to be
                 // collected for the pixel shader. Some packages might use this to customize the scene picking rendering.
                 validPixelBlocks = CoreBlockMasks.FragmentColorAlpha,
 
@@ -1541,7 +1541,6 @@ namespace UnityEditor.Rendering.Universal.ShaderGraph
                 { RenderState.ZTest(ZTest.LEqual) },
                 { RenderState.ZWrite(ZWrite.On) },
                 { UberSwitchedCullRenderState(target) },
-                { RenderState.ColorMask("ColorMask RG") },
             };
             return result;
         }
@@ -2272,6 +2271,15 @@ namespace UnityEditor.Rendering.Universal.ShaderGraph
         {
             displayName = "Use Legacy Lightmaps",
             referenceName = ShaderKeywordStrings.USE_LEGACY_LIGHTMAPS,
+            type = KeywordType.Boolean,
+            definition = KeywordDefinition.MultiCompile,
+            scope = KeywordScope.Global
+        };
+
+        public static readonly KeywordDescriptor ApplicationSpaceWarpMotion = new KeywordDescriptor()
+        {
+            displayName = ShaderKeywordStrings.APPLICATION_SPACE_WARP_MOTION,
+            referenceName = ShaderKeywordStrings.APPLICATION_SPACE_WARP_MOTION,
             type = KeywordType.Boolean,
             definition = KeywordDefinition.MultiCompile,
             scope = KeywordScope.Global

--- a/Packages/com.unity.render-pipelines.universal/Runtime/FrameData/UniversalCameraData.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/FrameData/UniversalCameraData.cs
@@ -395,7 +395,7 @@ namespace UnityEngine.Rendering.Universal
             bool isBackbuffer = handleID == BuiltinRenderTextureType.CameraTarget || handleID == BuiltinRenderTextureType.Depth;
 #if ENABLE_VR && ENABLE_XR_MODULE
             if (xr.enabled)
-                isBackbuffer |= handleID == new RenderTargetIdentifier(xr.renderTarget, 0, CubemapFace.Unknown, 0);
+                isBackbuffer |= xr.IsXRTarget(handleID);
 #endif
             return !isBackbuffer;
         }

--- a/Packages/com.unity.render-pipelines.universal/Runtime/Passes/FinalBlitPass.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/Passes/FinalBlitPass.cs
@@ -224,7 +224,7 @@ namespace UnityEngine.Rendering.Universal.Internal
             bool isRenderToBackBufferTarget = !cameraData.isSceneViewCamera;
 #if ENABLE_VR && ENABLE_XR_MODULE
             if (cameraData.xr.enabled)
-                isRenderToBackBufferTarget = new RenderTargetIdentifier(destination.nameID, 0, CubemapFace.Unknown, -1) == new RenderTargetIdentifier(cameraData.xr.renderTarget, 0, CubemapFace.Unknown, -1);
+                isRenderToBackBufferTarget = cameraData.xr.IsXRTarget(destination);
 #endif
             Vector4 scaleBias = RenderingUtils.GetFinalBlitScaleBias(source, destination, cameraData);
             if (isRenderToBackBufferTarget)

--- a/Packages/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPassRenderGraph.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPassRenderGraph.cs
@@ -1591,7 +1591,7 @@ namespace UnityEngine.Rendering.Universal
                     bool isRenderToBackBufferTarget = !data.cameraData.isSceneViewCamera;
 #if ENABLE_VR && ENABLE_XR_MODULE
                     if (data.cameraData.xr.enabled)
-                        isRenderToBackBufferTarget = destinationTextureHdl == data.cameraData.xr.renderTarget;
+                        isRenderToBackBufferTarget = data.cameraData.xr.IsXRTarget(destinationTextureHdl);
 #endif
                     // HDR debug views force-renders to DebugScreenTexture.
                     isRenderToBackBufferTarget &= !resolveToDebugScreen;

--- a/Packages/com.unity.render-pipelines.universal/Runtime/RenderingUtils.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/RenderingUtils.cs
@@ -229,8 +229,8 @@ namespace UnityEngine.Rendering.Universal
         {
             bool isRenderToBackBufferTarget = !cameraData.isSceneViewCamera;
 #if ENABLE_VR && ENABLE_XR_MODULE
-                if (cameraData.xr.enabled)
-                    isRenderToBackBufferTarget = new RenderTargetIdentifier(destination.nameID, 0, CubemapFace.Unknown, -1) == new RenderTargetIdentifier(cameraData.xr.renderTarget, 0, CubemapFace.Unknown, -1);
+            if (cameraData.xr.enabled)
+                isRenderToBackBufferTarget = cameraData.xr.IsXRTarget(destination);
 #endif
 
             Vector2 viewportScale = source.useScaling ? new Vector2(source.rtHandleProperties.rtHandleScale.x, source.rtHandleProperties.rtHandleScale.y) : Vector2.one;
@@ -574,6 +574,17 @@ namespace UnityEngine.Rendering.Universal
                     return false;
 
             return true;
+        }
+
+        internal static bool ContainsXRTarget(RTHandle[] source, in XRPass xr)
+        {
+            for (int i = 0; i < source.Length; ++i)
+            {
+                if (source[i] != null && xr.IsXRTarget(source[i].nameID))
+                    return true;
+            }
+
+            return false;
         }
 
         internal static bool MultisampleDepthResolveSupported()

--- a/Packages/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
@@ -1887,8 +1887,7 @@ namespace UnityEngine.Rendering.Universal
                         {
                             // SetRenderTarget might alter the internal device state(winding order).
                             // Non-stereo buffer is already updated internally when switching render target. We update stereo buffers here to keep the consistency.
-                            int xrTargetIndex = RenderingUtils.IndexOf(renderPass.colorAttachmentHandles, cameraData.xr.renderTarget);
-                            bool renderIntoTexture = xrTargetIndex == -1;
+                            bool renderIntoTexture = !RenderingUtils.ContainsXRTarget(renderPass.colorAttachmentHandles, cameraData.xr);
                             cameraData.PushBuiltinShaderConstantsXR(CommandBufferHelpers.GetRasterCommandBuffer(cmd), renderIntoTexture);
                             XRSystemUniversal.MarkShaderProperties(CommandBufferHelpers.GetRasterCommandBuffer(cmd), cameraData.xrUniversal, renderIntoTexture);
                         }
@@ -2013,7 +2012,7 @@ namespace UnityEngine.Rendering.Universal
                         {
                             // SetRenderTarget might alter the internal device state(winding order).
                             // Non-stereo buffer is already updated internally when switching render target. We update stereo buffers here to keep the consistency.
-                            bool renderIntoTexture = passColorAttachment.nameID != cameraData.xr.renderTarget;
+                            bool renderIntoTexture = !cameraData.xr.IsXRTarget(passColorAttachment.nameID);
                             cameraData.PushBuiltinShaderConstantsXR(CommandBufferHelpers.GetRasterCommandBuffer(cmd), renderIntoTexture);
                             XRSystemUniversal.MarkShaderProperties(CommandBufferHelpers.GetRasterCommandBuffer(cmd), cameraData.xrUniversal, renderIntoTexture);
                         }

--- a/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
@@ -1441,6 +1441,9 @@ namespace UnityEngine.Rendering.Universal
 
         /// <summary> Keyword used for enable alpha output. Used in post processing. </summary>
         public const string _ENABLE_ALPHA_OUTPUT = "_ENABLE_ALPHA_OUTPUT";
+
+        /// <summary> Keyword used for application space warp for XR devices. </summary>
+        public const string APPLICATION_SPACE_WARP_MOTION = "APPLICATION_SPACE_WARP_MOTION";
     }
 
     public sealed partial class UniversalRenderPipeline

--- a/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRenderer.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRenderer.cs
@@ -47,6 +47,9 @@ namespace UnityEngine.Rendering.Universal
 
         const int k_FinalBlitPassQueueOffset = 1;
         const int k_AfterFinalBlitPassQueueOffset = k_FinalBlitPassQueueOffset + 1;
+        #if ENABLE_VR && ENABLE_XR_MODULE
+        const int k_AfterXRCopyDepthQueueOffset = k_AfterFinalBlitPassQueueOffset + 1;
+        #endif
 
         static readonly List<ShaderTagId> k_DepthNormalsOnly = new List<ShaderTagId> { new ShaderTagId("DepthNormalsOnly") };
 
@@ -190,7 +193,7 @@ namespace UnityEngine.Rendering.Universal
             if (GraphicsSettings.TryGetRenderPipelineSettings<UniversalRenderPipelineRuntimeXRResources>(out var xrResources))
             {
                 Experimental.Rendering.XRSystem.Initialize(XRPassUniversal.Create, xrResources.xrOcclusionMeshPS, xrResources.xrMirrorViewPS);
-                m_XRDepthMotionPass = new XRDepthMotionPass(RenderPassEvent.BeforeRenderingPrePasses, xrResources.xrMotionVector);
+                m_XRDepthMotionPass = new XRDepthMotionPass(RenderPassEvent.AfterRendering + k_AfterXRCopyDepthQueueOffset, xrResources.xrMotionVector);
             }
 #endif
             if (GraphicsSettings.TryGetRenderPipelineSettings<UniversalRenderPipelineRuntimeShaders>(

--- a/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRenderer.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRenderer.cs
@@ -1491,6 +1491,13 @@ namespace UnityEngine.Rendering.Universal
                         m_XRCopyDepthPass.CopyToDepthXR = true;
                         EnqueuePass(m_XRCopyDepthPass);
                     }
+
+                    if (cameraData.xr.hasMotionVectorPass && m_XRDepthMotionPass != null)
+                    {
+                        m_XRDepthMotionPass.Update(ref cameraData);
+                        m_XRDepthMotionPass.Setup(in cameraData, m_ActiveCameraColorAttachment);
+                        EnqueuePass(m_XRDepthMotionPass);
+                    }
                 }
 #endif
             }

--- a/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRendererRenderGraph.cs
+++ b/Packages/com.unity.render-pipelines.universal/Runtime/UniversalRendererRenderGraph.cs
@@ -1163,17 +1163,6 @@ namespace UnityEngine.Rendering.Universal
 
             bool needsOccluderUpdate = cameraData.useGPUOcclusionCulling;
 
-#if ENABLE_VR && ENABLE_XR_MODULE
-            if (cameraData.xr.enabled && cameraData.xr.hasMotionVectorPass)
-            {
-                // Update prevView and View matrices.
-                m_XRDepthMotionPass?.Update(ref cameraData);
-
-                // Record depthMotion pass and import XR resources into the rendergraph.
-                m_XRDepthMotionPass?.Render(renderGraph, frameData);
-            }
-#endif
-
             if (requiresDepthPrepass)
             {
                 // If we're in deferred mode, prepasses always render directly to the depth attachment rather than the camera depth texture.
@@ -1614,6 +1603,16 @@ namespace UnityEngine.Rendering.Universal
                     m_XRCopyDepthPass.CopyToDepthXR = true;
                     m_XRCopyDepthPass.MssaSamples = 1;
                     m_XRCopyDepthPass.Render(renderGraph, frameData, resourceData.backBufferDepth, resourceData.cameraDepth, bindAsCameraDepth: false, "XR Depth Copy");
+                }
+
+                // Populate XR motionVector color+depth as requested by XR provider
+                if (cameraData.xr.hasMotionVectorPass)
+                {
+                    // Update prevView and View matrices.
+                    m_XRDepthMotionPass?.Update(ref cameraData);
+
+                    // Record depthMotion pass and import XR resources into the rendergraph.
+                    m_XRDepthMotionPass?.Render(renderGraph, frameData);
                 }
             }
 #endif

--- a/Packages/com.unity.render-pipelines.universal/ShaderLibrary/ObjectMotionVectors.hlsl
+++ b/Packages/com.unity.render-pipelines.universal/ShaderLibrary/ObjectMotionVectors.hlsl
@@ -87,7 +87,7 @@ Varyings vert(Attributes input)
 
     output.previousPositionCSNoJitter = mul(_PrevViewProjMatrix, mul(UNITY_PREV_MATRIX_M, prevPos));
 
-#if !defined(APLICATION_SPACE_WARP_MOTION)
+#if !defined(APPLICATION_SPACE_WARP_MOTION)
     ApplyMotionVectorZBias(output.positionCS);
 #endif
 
@@ -109,7 +109,7 @@ float4 frag(Varyings input) : SV_Target
         LODFadeCrossFade(input.positionCS);
     #endif
 
-    #if defined(APLICATION_SPACE_WARP_MOTION)
+    #if defined(APPLICATION_SPACE_WARP_MOTION)
         return float4(CalcAswNdcMotionVectorFromCsPositions(input.positionCSNoJitter, input.previousPositionCSNoJitter), 1);
     #else
         return float4(CalcNdcMotionVectorFromCsPositions(input.positionCSNoJitter, input.previousPositionCSNoJitter), 0, 0);

--- a/Packages/com.unity.render-pipelines.universal/ShaderLibrary/ObjectMotionVectors.hlsl
+++ b/Packages/com.unity.render-pipelines.universal/ShaderLibrary/ObjectMotionVectors.hlsl
@@ -87,7 +87,9 @@ Varyings vert(Attributes input)
 
     output.previousPositionCSNoJitter = mul(_PrevViewProjMatrix, mul(UNITY_PREV_MATRIX_M, prevPos));
 
+#if !defined(APLICATION_SPACE_WARP_MOTION)
     ApplyMotionVectorZBias(output.positionCS);
+#endif
 
     return output;
 }

--- a/Packages/com.unity.render-pipelines.universal/Shaders/BakedLit.shader
+++ b/Packages/com.unity.render-pipelines.universal/Shaders/BakedLit.shader
@@ -308,38 +308,12 @@ Shader "Universal Render Pipeline/Baked Lit"
         {
             Name "MotionVectors"
             Tags { "LightMode" = "MotionVectors" }
-            ColorMask RG
 
             HLSLPROGRAM
             #pragma shader_feature_local _ALPHATEST_ON
             #pragma multi_compile _ LOD_FADE_CROSSFADE
+            #pragma multi_compile _ APPLICATION_SPACE_WARP_MOTION
             #pragma shader_feature_local_vertex _ADD_PRECOMPUTED_VELOCITY
-
-            #include "Packages/com.unity.render-pipelines.universal/Shaders/BakedLitInput.hlsl"
-            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ObjectMotionVectors.hlsl"
-            ENDHLSL
-        }
-
-        Pass
-        {
-            Name "XRMotionVectors"
-            Tags { "LightMode" = "XRMotionVectors" }
-            ColorMask RGBA
-
-            // Stencil write for obj motion pixels
-            Stencil
-            {
-                WriteMask 1
-                Ref 1
-                Comp Always
-                Pass Replace
-            }
-
-            HLSLPROGRAM
-            #pragma shader_feature_local _ALPHATEST_ON
-            #pragma multi_compile _ LOD_FADE_CROSSFADE
-            #pragma shader_feature_local_vertex _ADD_PRECOMPUTED_VELOCITY
-            #define APLICATION_SPACE_WARP_MOTION 1
 
             #include "Packages/com.unity.render-pipelines.universal/Shaders/BakedLitInput.hlsl"
             #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ObjectMotionVectors.hlsl"

--- a/Packages/com.unity.render-pipelines.universal/Shaders/ComplexLit.shader
+++ b/Packages/com.unity.render-pipelines.universal/Shaders/ComplexLit.shader
@@ -481,38 +481,12 @@ Shader "Universal Render Pipeline/Complex Lit"
         {
             Name "MotionVectors"
             Tags { "LightMode" = "MotionVectors" }
-            ColorMask RG
 
             HLSLPROGRAM
             #pragma shader_feature_local _ALPHATEST_ON
             #pragma multi_compile _ LOD_FADE_CROSSFADE
+            #pragma multi_compile _ APPLICATION_SPACE_WARP_MOTION
             #pragma shader_feature_local_vertex _ADD_PRECOMPUTED_VELOCITY
-
-            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
-            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ObjectMotionVectors.hlsl"
-            ENDHLSL
-        }
-
-        Pass
-        {
-            Name "XRMotionVectors"
-            Tags { "LightMode" = "XRMotionVectors" }
-            ColorMask RGB
-
-            // Stencil write for obj motion pixels
-            Stencil
-            {
-                WriteMask 1
-                Ref 1
-                Comp Always
-                Pass Replace
-            }
-
-            HLSLPROGRAM
-            #pragma shader_feature_local _ALPHATEST_ON
-            #pragma multi_compile _ LOD_FADE_CROSSFADE
-            #pragma shader_feature_local_vertex _ADD_PRECOMPUTED_VELOCITY
-            #define APLICATION_SPACE_WARP_MOTION 1
 
             #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
             #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ObjectMotionVectors.hlsl"

--- a/Packages/com.unity.render-pipelines.universal/Shaders/Lit.shader
+++ b/Packages/com.unity.render-pipelines.universal/Shaders/Lit.shader
@@ -479,38 +479,12 @@ Shader "Universal Render Pipeline/Lit"
         {
             Name "MotionVectors"
             Tags { "LightMode" = "MotionVectors" }
-            ColorMask RG
 
             HLSLPROGRAM
             #pragma shader_feature_local _ALPHATEST_ON
             #pragma multi_compile _ LOD_FADE_CROSSFADE
+            #pragma multi_compile _ APPLICATION_SPACE_WARP_MOTION
             #pragma shader_feature_local_vertex _ADD_PRECOMPUTED_VELOCITY
-
-            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
-            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ObjectMotionVectors.hlsl"
-            ENDHLSL
-        }
-
-        Pass
-        {
-            Name "XRMotionVectors"
-            Tags { "LightMode" = "XRMotionVectors" }
-            ColorMask RGBA
-
-            // Stencil write for obj motion pixels
-            Stencil
-            {
-                WriteMask 1
-                Ref 1
-                Comp Always
-                Pass Replace
-            }
-
-            HLSLPROGRAM
-            #pragma shader_feature_local _ALPHATEST_ON
-            #pragma multi_compile _ LOD_FADE_CROSSFADE
-            #pragma shader_feature_local_vertex _ADD_PRECOMPUTED_VELOCITY
-            #define APLICATION_SPACE_WARP_MOTION 1
 
             #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
             #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ObjectMotionVectors.hlsl"

--- a/Packages/com.unity.render-pipelines.universal/Shaders/ObjectMotionVectorFallback.shader
+++ b/Packages/com.unity.render-pipelines.universal/Shaders/ObjectMotionVectorFallback.shader
@@ -7,30 +7,9 @@ Shader "Hidden/Universal Render Pipeline/ObjectMotionVectorFallback"
             Name "MotionVectors"
 
             Tags{ "LightMode" = "MotionVectors" }
-            ColorMask RG
 
             HLSLPROGRAM
-            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ObjectMotionVectors.hlsl"
-            ENDHLSL
-        }
-
-        Pass
-        {
-            Name "XRMotionVectors"
-            Tags { "LightMode" = "XRMotionVectors" }
-            ColorMask RGB
-
-            // Stencil write for obj motion pixels
-            Stencil
-            {
-                WriteMask 1
-                Ref 1
-                Comp Always
-                Pass Replace
-            }
-
-            HLSLPROGRAM
-            #define APLICATION_SPACE_WARP_MOTION 1
+            #pragma multi_compile _ APPLICATION_SPACE_WARP_MOTION
             #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ObjectMotionVectors.hlsl"
             ENDHLSL
         }

--- a/Packages/com.unity.render-pipelines.universal/Shaders/SimpleLit.shader
+++ b/Packages/com.unity.render-pipelines.universal/Shaders/SimpleLit.shader
@@ -425,38 +425,13 @@ Shader "Universal Render Pipeline/Simple Lit"
         {
             Name "MotionVectors"
             Tags { "LightMode" = "MotionVectors" }
-            ColorMask RG
 
             HLSLPROGRAM
             #pragma shader_feature_local _ALPHATEST_ON
             #pragma multi_compile _ LOD_FADE_CROSSFADE
+            #pragma multi_compile _ APPLICATION_SPACE_WARP_MOTION
             #pragma shader_feature_local_vertex _ADD_PRECOMPUTED_VELOCITY
 
-            #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitInput.hlsl"
-            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ObjectMotionVectors.hlsl"
-            ENDHLSL
-        }
-
-        Pass
-        {
-            Name "XRMotionVectors"
-            Tags { "LightMode" = "XRMotionVectors" }
-            ColorMask RGBA
-
-            // Stencil write for obj motion pixels
-            Stencil
-            {
-                WriteMask 1
-                Ref 1
-                Comp Always
-                Pass Replace
-            }
-
-            HLSLPROGRAM
-            #pragma shader_feature_local _ALPHATEST_ON
-            #pragma multi_compile _ LOD_FADE_CROSSFADE
-            #pragma shader_feature_local_vertex _ADD_PRECOMPUTED_VELOCITY
-            #define APLICATION_SPACE_WARP_MOTION 1
             #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitInput.hlsl"
             #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ObjectMotionVectors.hlsl"
             ENDHLSL

--- a/Packages/com.unity.render-pipelines.universal/Shaders/Unlit.shader
+++ b/Packages/com.unity.render-pipelines.universal/Shaders/Unlit.shader
@@ -255,38 +255,13 @@ Shader "Universal Render Pipeline/Unlit"
         {
             Name "MotionVectors"
             Tags { "LightMode" = "MotionVectors" }
-            ColorMask RG
 
             HLSLPROGRAM
             #pragma shader_feature_local _ALPHATEST_ON
             #pragma multi_compile _ LOD_FADE_CROSSFADE
+            #pragma multi_compile _ APPLICATION_SPACE_WARP_MOTION
             #pragma shader_feature_local_vertex _ADD_PRECOMPUTED_VELOCITY
 
-            #include "Packages/com.unity.render-pipelines.universal/Shaders/UnlitInput.hlsl"
-            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ObjectMotionVectors.hlsl"
-            ENDHLSL
-        }
-
-        Pass
-        {
-            Name "XRMotionVectors"
-            Tags { "LightMode" = "XRMotionVectors" }
-            ColorMask RGBA
-
-            // Stencil write for obj motion pixels
-            Stencil
-            {
-                WriteMask 1
-                Ref 1
-                Comp Always
-                Pass Replace
-            }
-
-            HLSLPROGRAM
-            #pragma shader_feature_local _ALPHATEST_ON
-            #pragma multi_compile _ LOD_FADE_CROSSFADE
-            #pragma shader_feature_local_vertex _ADD_PRECOMPUTED_VELOCITY
-            #define APLICATION_SPACE_WARP_MOTION 1
             #include "Packages/com.unity.render-pipelines.universal/Shaders/UnlitInput.hlsl"
             #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ObjectMotionVectors.hlsl"
             ENDHLSL

--- a/Packages/com.unity.render-pipelines.universal/Shaders/XR/XRMotionVector.shader
+++ b/Packages/com.unity.render-pipelines.universal/Shaders/XR/XRMotionVector.shader
@@ -4,6 +4,7 @@ Shader "Hidden/Universal Render Pipeline/XR/XRMotionVector"
     {
         Tags{ "RenderPipeline" = "UniversalPipeline" }
 
+        // Pass 0: Draw camera motion vector
         Pass
         {
             Name "XR Camera MotionVectors"
@@ -45,7 +46,8 @@ Shader "Hidden/Universal Render Pipeline/XR/XRMotionVector"
             struct Varyings
             {
                 float4 position : SV_POSITION;
-                float3 posWS : TEXCOORD0;
+                float4 posCS : TEXCOORD0;
+                float4 prevPosCS : TEXCOORD1;
                 UNITY_VERTEX_OUTPUT_STEREO
             };
 
@@ -63,7 +65,11 @@ Shader "Hidden/Universal Render Pipeline/XR/XRMotionVector"
                 output.position.z = depth;
 
                 // Reconstruct world position
-                output.posWS = ComputeWorldSpacePosition(output.position.xy, depth, UNITY_MATRIX_I_VP);
+                float4 posWS = mul(UNITY_MATRIX_I_VP, output.position);
+
+                // Multiply with current and previous non-jittered view projection
+                output.posCS = mul(_NonJitteredViewProjMatrix, posWS.xyz);
+                output.prevPosCS = mul(_PrevViewProjMatrix, posWS.xyz);
 
                 return output;
             }
@@ -74,9 +80,105 @@ Shader "Hidden/Universal Render Pipeline/XR/XRMotionVector"
             {
                 UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
 
+                // Non-uniform raster needs to keep the posNDC values in float to avoid additional conversions
+                // since uv remap functions use floats
+                float3 posNDC = input.posCS.xyz * rcp(input.posCS.w);
+                float3 prevPosNDC = input.prevPosCS.xyz * rcp(input.prevPosCS.w);
+
+                // Calculate forward velocity
+                float3 velocity = (posNDC - prevPosNDC);
+
+                return float4(velocity.xyz, 0);
+            }
+            ENDHLSL
+        }
+
+        // Pass 1: Blit valid depth data from _XRDepthTexture to motionvector depth target
+        Pass
+        {
+            Name "XR MotionVector Depth Copy"
+
+            Cull Off
+            ZWrite On
+            ColorMask RGBA
+
+            HLSLPROGRAM
+            #pragma target 3.5
+            #pragma multi_compile_fragment _ _SUBSAMPLE_DEPTH
+
+            #pragma vertex Vert
+            #pragma fragment Frag
+
+            // -------------------------------------
+            // Includes
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            // -------------------------------------
+            // Structs
+            struct Attributes
+            {
+                uint vertexID   : SV_VertexID;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct Varyings
+            {
+                float4 position : SV_POSITION;
+                float4 posCS : TEXCOORD0;
+                float2 uv : TEXCOORD1;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            // -------------------------------------
+            // Vertex
+            Varyings Vert(Attributes input)
+            {
+                Varyings output;
+                UNITY_SETUP_INSTANCE_ID(input);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+                output.position = GetFullScreenTriangleVertexPosition(input.vertexID);
+                output.posCS = output.position;
+                output.uv = GetFullScreenTriangleTexCoord(input.vertexID);
+                return output;
+            }
+
+            TEXTURE2D_X(_XRDepthTexture);
+            SAMPLER(sampler_XRDepthTexture);
+
+            // -------------------------------------
+            // Fragment
+            float4 Frag(Varyings input, out float outDepth : SV_Depth) : SV_Target
+            {
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
+
+                float2 uv = input.uv;
+
+             #if _SUBSAMPLE_DEPTH
+                float4 depth4 = GATHER_RED_TEXTURE2D_X(_XRDepthTexture, sampler_XRDepthTexture, uv);
+                #if UNITY_REVERSED_Z
+                    float depth = min(min(depth4.x, depth4.y), min(depth4.z, depth4.w));
+                #else
+                    float depth = max(max(depth4.x, depth4.y), max(depth4.z, depth4.w));
+                #endif
+            #else
+                float depth = SAMPLE_TEXTURE2D_X(_XRDepthTexture, sampler_XRDepthTexture, uv).x;
+            #endif
+
+                // This is required to avoid artifacts from the motion vector pass outputting the same z
+            #if UNITY_REVERSED_Z
+                outDepth = depth - 0.0001; // Write depth with a small offset
+            #else
+                outDepth = depth + 0.0001; // Write depth with a small offset
+            #endif
+
+                // Calculate world pos from jittered clipspace pos
+                float4 jitteredPosCS = float4(input.posCS.xy, depth, 1.0);
+                float4 posWS = mul(UNITY_MATRIX_I_VP, jitteredPosCS);
+
                 // Multiply with current and previous non-jittered view projection
-                float4 posCS = mul(_NonJitteredViewProjMatrix, float4(input.posWS.xyz, 1.0));
-                float4 prevPosCS = mul(_PrevViewProjMatrix, float4(input.posWS.xyz, 1.0));
+                float4 posCS = mul(_NonJitteredViewProjMatrix, posWS);
+                float4 prevPosCS = mul(_PrevViewProjMatrix, posWS);
 
                 // Non-uniform raster needs to keep the posNDC values in float to avoid additional conversions
                 // since uv remap functions use floats


### PR DESCRIPTION
* https://github.com/nukadelic/Unity-Graphics/compare/6000.0/based...nukadelic:Unity-Graphics:6000.0/oculus-app-spacewarp
* * Move XRDepthMotionPass after rendering, if possible use depth buffer to pre-fill static motion vectors [496b720](https://github.com/nukadelic/Unity-Graphics/commit/496b72078dba6f07c3bd0564de3c65aae57b910c)
* * Combine XRMotionVectors pass and MotionVectors pass. Modify ShaderGraph to add APPLICATION_SPACE_WARP_MOTION keyword to generated MotionVectors pass [fc14d1f](https://github.com/nukadelic/Unity-Graphics/commit/fc14d1fed1c5376886e4742f0a52de77cb113f5b)
* * Add XRDepthMotionPass support for legacy non-rendergraph URP [e4004f9](https://github.com/nukadelic/Unity-Graphics/commit/e4004f9613caecec4714f96a40e634f17ad0114b)